### PR TITLE
Update Makefile to use 'go env -w' for setting GOOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ build_all: build_windows build_linux
 
 .PHONY: build_windows
 build_windows:
-	$(GOCMD) env GOOS=windows 
+	$(GOCMD) env -w GOOS=windows 
 	${GOBUILD} -o ${WINDOWS_BIN} ./main/
 
 .PHONY: build_linux
 build_linux:
-	$(GOCMD) env GOOS=linux
+	$(GOCMD) env -w GOOS=linux
 	${GOBUILD} -o  ${LINUX_BIN} ./main/
 	${GOBUILD} -o  ${SERVICE_SCRIPT_BIN} ./services/
 


### PR DESCRIPTION
This pull request involves a minor change in the `Makefile`, It Changes the `build_linux` & `build_windows` make commands to use `go env -w` to set the GOOS.