### PR TITLE
Change version to 0.9.0.0 for signature validation test

### DIFF
--- a/HandlerManifest.json
+++ b/HandlerManifest.json
@@ -21,5 +21,10 @@
       ],
       "cpuQuotaPercentage" : 10,
       "memoryQuotaInMB" : 20
+    },
+    "signingInfo": {
+      "version": "0.9.0",
+      "type": "GATestExtGo",
+      "publisher": "Microsoft.Azure.Extensions.Edp"
     }
 }]

--- a/main/main.go
+++ b/main/main.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	versionMajor    = "0"
-	versionMinor    = "8"
+	versionMinor    = "9"
 	versionBuild    = "0"
 	versionRevision = "0"
 	version         = fmt.Sprintf("%s.%s.%s.%s", versionMajor, versionMinor, versionBuild, versionRevision)

--- a/main/main.go
+++ b/main/main.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	versionMajor    = "1"
-	versionMinor    = "2"
+	versionMinor    = "3"
 	versionBuild    = "0"
 	versionRevision = "0"
 	version         = fmt.Sprintf("%s.%s.%s.%s", versionMajor, versionMinor, versionBuild, versionRevision)

--- a/main/main.go
+++ b/main/main.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	versionMajor    = "1"
-	versionMinor    = "3"
+	versionMajor    = "0"
+	versionMinor    = "8"
 	versionBuild    = "0"
 	versionRevision = "0"
 	version         = fmt.Sprintf("%s.%s.%s.%s", versionMajor, versionMinor, versionBuild, versionRevision)


### PR DESCRIPTION
This extension will be published with invalid signature on canary regions for signature validation testing purposes. This PR changes the version from "1.2.0.0" to "0.9.0.0", and adds a "signingInfo" section to the handler manifest. This change will be reverted after the extension is published.